### PR TITLE
Fix md5 mismatch error

### DIFF
--- a/BugSplatDotNetStandard.Test/BugSplat.cs
+++ b/BugSplatDotNetStandard.Test/BugSplat.cs
@@ -88,9 +88,7 @@ namespace Tests
             };
             options.AdditionalAttachments.Add(new FileInfo("attachment.txt"));
 
-            var md5 = "B7AAAD5CD414C986C98B7560478DB0A2";
-            
-            var response = sut.Post(minidumpFileInfo, options, md5).Result;
+            var response = sut.Post(minidumpFileInfo, options).Result;
             var body = response.Content.ReadAsStringAsync().Result;
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);

--- a/BugSplatDotNetStandard.Test/BugSplatDotNetStandard.Test.csproj
+++ b/BugSplatDotNetStandard.Test/BugSplatDotNetStandard.Test.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
   </ItemGroup>
 

--- a/BugSplatDotNetStandard/BugSplat.cs
+++ b/BugSplatDotNetStandard/BugSplat.cs
@@ -175,8 +175,8 @@ namespace BugSplatDotNetStandard
             try
             {
                 var json = await response.Content.ReadAsStringAsync();
-                var awsResponse = JsonConvert.DeserializeObject<AWSResponse>(json);
-                return new Uri(awsResponse.Url);
+                var presignedUrlResponse = JsonConvert.DeserializeObject<GetPresignedUrlResponse>(json);
+                return new Uri(presignedUrlResponse.Url);
             }
             catch
             {

--- a/BugSplatDotNetStandard/BugSplatDotNetStandard.csproj
+++ b/BugSplatDotNetStandard/BugSplatDotNetStandard.csproj
@@ -31,4 +31,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/BugSplatDotNetStandard/BugSplatPostOptions.cs
+++ b/BugSplatDotNetStandard/BugSplatPostOptions.cs
@@ -73,7 +73,7 @@ namespace BugSplatDotNetStandard
         public string FileName { get; set; } = string.Empty;
     }
 
-    internal class AWSResponse
+    internal class GetPresignedUrlResponse
     {
         public string Url;
     }


### PR DESCRIPTION
* Fixes md5 mismatch error my grabbing ETag from S3 response headers
* Adds missing Newtonsoft dependency reference
* Updates tests to .NET Core 3.1. so they can run on macOS